### PR TITLE
lib: expose index modules as public

### DIFF
--- a/src/advanced_bookmark_mode/command.rs
+++ b/src/advanced_bookmark_mode/command.rs
@@ -4,7 +4,7 @@ use crate::{
     MessageType,
 };
 
-mod index {
+pub mod index {
     pub const STATUS: usize = 7;
 }
 

--- a/src/advanced_bookmark_mode/reply.rs
+++ b/src/advanced_bookmark_mode/reply.rs
@@ -7,7 +7,7 @@ use crate::{
     MessageType, OmnibusReplyOps,
 };
 
-mod index {
+pub mod index {
     pub const ACKNAK: usize = 10;
 }
 

--- a/src/aux_command.rs
+++ b/src/aux_command.rs
@@ -81,7 +81,7 @@ impl fmt::Display for AuxCommand {
     }
 }
 
-pub(crate) mod index {
+pub mod index {
     pub const COMMAND: usize = 5;
 }
 

--- a/src/banknote.rs
+++ b/src/banknote.rs
@@ -706,8 +706,7 @@ mod tests {
         assert_eq!(Sign::from(b'+'), sign_pos);
         assert_eq!(Sign::from(b'-'), sign_neg);
 
-        for i in 0..=u8::MAX {
-            let b = i as u8;
+        for b in 0..=u8::MAX {
             if b != b'-' {
                 assert_eq!(Sign::from(b), sign_pos);
             }
@@ -734,12 +733,12 @@ mod tests {
             assert_eq!(Exponent::from([i]), exp_def);
 
             for j in 0..=u8::MAX {
-                if i == b'+' && j >= b'0' && j <= b'9' {
+                if i == b'+' && (b'0'..=b'9').contains(&j) {
                     assert_eq!(
                         Exponent::from([i, j]),
                         Exponent(std::str::from_utf8(&[j]).unwrap().parse::<u8>().unwrap())
                     );
-                } else if i < b'0' || i > b'9' || j < b'0' || j > b'9' {
+                } else if !(b'0'..=b'9').contains(&i) || !(b'0'..=b'9').contains(&j) {
                     // Check that values outside the valid range are parsed as the default value
                     assert_eq!(
                         Exponent::from([i, j]),
@@ -824,7 +823,7 @@ mod tests {
         ];
 
         for c in 0..=u8::MAX {
-            if c >= 32 && c <= 126 {
+            if (32..=126).contains(&c) {
                 let ascii_index = (c - 32) as usize;
                 let ascii_val = ascii_table[ascii_index];
 

--- a/src/clear_audit_data/reply.rs
+++ b/src/clear_audit_data/reply.rs
@@ -17,7 +17,7 @@ bool_enum!(
     r"Whether the device successfully proccessed the Clear Audit Data Request."
 );
 
-mod index {
+pub mod index {
     pub const ACKNAK: usize = 10;
     pub const PASS_FAIL: usize = 10;
 }

--- a/src/extended_command.rs
+++ b/src/extended_command.rs
@@ -79,7 +79,7 @@ impl fmt::Display for ExtendedCommand {
     }
 }
 
-mod index {
+pub mod index {
     pub const SUBTYPE: usize = 3;
 }
 

--- a/src/extended_note_inhibits/command.rs
+++ b/src/extended_note_inhibits/command.rs
@@ -17,7 +17,7 @@ mod bitmask {
     pub const ENABLE_NOTE: u8 = 0b111_1111;
 }
 
-mod index {
+pub mod index {
     pub const ENABLE_NOTE: usize = 7;
 }
 

--- a/src/extended_note_inhibits/reply.rs
+++ b/src/extended_note_inhibits/reply.rs
@@ -7,7 +7,7 @@ use crate::{
     MessageType, OmnibusReply,
 };
 
-mod index {
+pub mod index {
     pub const DATA: usize = 4;
 }
 

--- a/src/extended_note_specification/query.rs
+++ b/src/extended_note_specification/query.rs
@@ -4,7 +4,7 @@ use crate::{
     ExtendedNoteReporting, MessageOps, MessageType, OmnibusCommandOps,
 };
 
-mod index {
+pub mod index {
     pub const NOTE_INDEX: usize = 7;
 }
 

--- a/src/extended_note_specification/reply.rs
+++ b/src/extended_note_specification/reply.rs
@@ -63,7 +63,7 @@ impl From<&ExtendedNoteReply> for DocumentStatus {
     }
 }
 
-mod index {
+pub mod index {
     use super::{BaseValue, Exponent, ISOCode};
 
     pub const EXTENDED: usize = 10;

--- a/src/extended_reply.rs
+++ b/src/extended_reply.rs
@@ -3,7 +3,7 @@ use crate::{
     MiscDeviceState, ModelNumber,
 };
 
-mod index {
+pub mod index {
     pub const SUBTYPE: usize = 3;
     pub const DEVICE_STATE: usize = SUBTYPE + 1;
     pub const DEVICE_STATUS: usize = SUBTYPE + 2;

--- a/src/flash_download/baud_rate.rs
+++ b/src/flash_download/baud_rate.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[allow(dead_code)]
-mod index {
+pub mod index {
     pub const DATA0: usize = 3;
     pub const BAUD_RATE: usize = 3;
 }

--- a/src/flash_download/message_7bit.rs
+++ b/src/flash_download/message_7bit.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use super::FlashDownloadMessage;
 
-mod index {
+pub mod index {
     pub const PACKET0: usize = 3;
     //pub const PACKET1: usize = 4;
     //pub const PACKET2: usize = 5;

--- a/src/flash_download/message_8bit.rs
+++ b/src/flash_download/message_8bit.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::FlashDownloadMessage;
 
-mod index {
+pub mod index {
     pub const PACKET0: usize = 3;
     pub const PACKET1: usize = 4;
     pub const DATA0: usize = 5;

--- a/src/flash_download/reply_7bit.rs
+++ b/src/flash_download/reply_7bit.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::FlashDownloadReply;
 
-mod index {
+pub mod index {
     pub const PACKET0: usize = 3;
     //pub const PACKET1: usize = 4;
     //pub const PACKET2: usize = 5;

--- a/src/flash_download/reply_8bit.rs
+++ b/src/flash_download/reply_8bit.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::FlashDownloadReply;
 
-mod index {
+pub mod index {
     pub const PACKET0: usize = 3;
     pub const PACKET1: usize = 4;
 }

--- a/src/flash_download/start_download/command.rs
+++ b/src/flash_download/start_download/command.rs
@@ -3,7 +3,7 @@ use crate::{
     MessageType,
 };
 
-mod index {
+pub mod index {
     pub const DATA2: usize = 5;
 }
 

--- a/src/flash_download/start_download/reply.rs
+++ b/src/flash_download/start_download/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     MessageOps, MessageType,
 };
 
-mod index {
+pub mod index {
     pub const DATA3: usize = 6;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,43 +1,43 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //! # EBDS Serial Protocol
-//! 
+//!
 //! This crate implements the EBDS serial protocol messages, and related types for communication with bill acceptor unit devices.
-//! 
+//!
 //! The currently supported messages are implemented in the various modules in this crate, along with some common types used across multiple messages.
-//! 
+//!
 //! If adding a new message, please follow the existing pattern of placing `...Command` (host-initiated) messages in `<message-type>/command.rs` files, and `...Reply` (device-initiated) messages in `<message-type>/reply.rs` files.
-//! 
+//!
 //! There are some exceptions to the general rule, e.g. when the types in the documenation do not follow the `Command/Reply` naming convention.
-//! 
+//!
 //! In those cases, the suffix is omitted to aid in readability when comparing with the EBDS specification.
-//! 
+//!
 //! ## Macros
-//! 
+//!
 //! Some simple macros exist for implementing traits over the various message types. All message types should implement `MessageOps`, and all reply types should implement `OmnibusReplyOps`.
-//! 
+//!
 //! `MessageOps` can be implemented with the helper macro `impl_message_ops!`, e.g. for a new `SomeNewReply` message:
-//! 
+//!
 //! ```rust
-//! use crate::impl_message_ops;
-//! 
+//! use ebds::impl_message_ops;
+//!
 //! pub struct SomeNewReply {
 //!     // For the example, we are just using a number for the length.
 //!     // In real implementations, please add a constant to the `len` module.
 //!     buf: [u8; 11],
 //! }
-//! 
+//!
 //! impl_message_ops!(SomeNewReply);
 //! ```
-//! 
+//!
 //! This will implement the `MessageOps` trait for `SomeNewReply`, and provide all of the associated functions. Traits are how Rust does polymorphism, similar to Go's `interface` and C++'s `template`, with important differences.
-//! 
+//!
 //! All of the macro implementations live in `src/macros.rs`.
-//! 
+//!
 //! ## Using with `std`
-//! 
+//!
 //! This library is `no-std` compatible by default. To use `std`-only features, add the `std` feature to the dependency:
-//! 
+//!
 //! ```toml
 //! ebds = { version = "0.1", features = ["std"] }
 //! ```
@@ -464,7 +464,7 @@ impl From<u8> for MessageType {
     }
 }
 
-pub(crate) mod index {
+pub mod index {
     pub const STX: usize = 0;
     pub const LEN: usize = 1;
     pub const CONTROL: usize = 2;
@@ -715,8 +715,7 @@ mod tests {
         assert_eq!(seven_bit_u16(u16_seven_bit(expected).as_ref()), expected);
 
         for num in 0..u16::MAX {
-            let n = num as u16;
-            assert_eq!(seven_bit_u16(u16_seven_bit(n).as_ref()), n);
+            assert_eq!(seven_bit_u16(u16_seven_bit(num).as_ref()), num);
         }
     }
 

--- a/src/note_retrieved/command.rs
+++ b/src/note_retrieved/command.rs
@@ -3,7 +3,7 @@ use crate::{
     len::NOTE_RETRIEVED_COMMAND, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
 };
 
-mod index {
+pub mod index {
     pub const STATUS: usize = 7;
 }
 

--- a/src/note_retrieved/reply.rs
+++ b/src/note_retrieved/reply.rs
@@ -14,7 +14,7 @@ bool_enum!(
     "Indicates success(0x01) / failure(0x00) of the NoteRetrievedCommand"
 );
 
-pub(crate) mod index {
+pub mod index {
     pub const ACKNAK: usize = 10;
     pub const EVENT: usize = 10;
 }

--- a/src/omnibus/command.rs
+++ b/src/omnibus/command.rs
@@ -282,7 +282,7 @@ bool_enum!(
 "
 );
 
-pub(crate) mod index {
+pub mod index {
     use crate::index::DATA;
 
     pub const DENOMINATION: usize = DATA;

--- a/src/omnibus/reply.rs
+++ b/src/omnibus/reply.rs
@@ -11,7 +11,7 @@ use crate::{
     QueryVariantPartNumberReply, SetEscrowTimeoutReply, StandardDenomination,
 };
 
-pub(crate) mod index {
+pub mod index {
     use crate::index::DATA;
 
     pub const DEVICE_STATE: usize = DATA;

--- a/src/query_application_id/reply.rs
+++ b/src/query_application_id/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     ApplicationPartNumber, MessageOps, MessageType, PartVersion, ProjectNumber,
 };
 
-mod index {
+pub mod index {
     pub const PROJECT_NUM: usize = 3;
     pub const VERSION: usize = 9;
 }

--- a/src/query_application_part_number/reply.rs
+++ b/src/query_application_part_number/reply.rs
@@ -7,7 +7,7 @@ use crate::{
     PartVersion, ProjectNumber,
 };
 
-mod index {
+pub mod index {
     pub const PROJECT_NUM: usize = 3;
     pub const VERSION: usize = 9;
 }

--- a/src/query_boot_part_number/reply.rs
+++ b/src/query_boot_part_number/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     BootPartNumber, MessageOps, MessageType, PartVersion, ProjectNumber,
 };
 
-mod index {
+pub mod index {
     pub const PROJECT_NUM: usize = 3;
     pub const VERSION: usize = 9;
 }

--- a/src/query_device_capabilities/reply.rs
+++ b/src/query_device_capabilities/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     MessageOps, MessageType, CLOSE_BRACE, OPEN_BRACE,
 };
 
-mod index {
+pub mod index {
     pub const CAP0: usize = 3;
     pub const CAP1: usize = 4;
     pub const CAP2: usize = 5;

--- a/src/query_software_crc/reply.rs
+++ b/src/query_software_crc/reply.rs
@@ -7,7 +7,7 @@ use crate::{
     MessageOps, MessageType,
 };
 
-mod index {
+pub mod index {
     pub const CRC_BEGIN: usize = 3;
     pub const CRC_END: usize = 7;
 }

--- a/src/query_value_table/reply.rs
+++ b/src/query_value_table/reply.rs
@@ -139,7 +139,7 @@ impl fmt::Display for BaseDenomination {
     }
 }
 
-mod index {
+pub mod index {
     use crate::{BaseDenomination, BaseValue, Exponent, ISOCode};
 
     pub const DENOM: usize = 10;

--- a/src/query_variant_id/reply.rs
+++ b/src/query_variant_id/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     MessageOps, MessageType, PartVersion, ProjectNumber, VariantPartNumber,
 };
 
-mod index {
+pub mod index {
     pub const PROJECT_NUM: usize = 3;
     pub const VERSION: usize = 9;
 }

--- a/src/query_variant_name/reply.rs
+++ b/src/query_variant_name/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     MessageOps, MessageType,
 };
 
-mod index {
+pub mod index {
     pub const DATA: usize = 3;
 }
 

--- a/src/query_variant_part_number/reply.rs
+++ b/src/query_variant_part_number/reply.rs
@@ -6,7 +6,7 @@ use crate::{
     MessageOps, MessageType, PartVersion, ProjectNumber, VariantPartNumber,
 };
 
-mod index {
+pub mod index {
     pub const PROJECT_NUM: usize = 3;
     pub const VERSION: usize = 9;
 }

--- a/src/set_escrow_timeout/command.rs
+++ b/src/set_escrow_timeout/command.rs
@@ -3,7 +3,7 @@ use crate::{
     len::SET_ESCROW_TIMEOUT_COMMAND, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
 };
 
-mod index {
+pub mod index {
     pub const NOTES: usize = 7;
     pub const BARCODES: usize = 8;
 }

--- a/src/soft_reset.rs
+++ b/src/soft_reset.rs
@@ -3,7 +3,7 @@ use crate::{
     MessageOps, MessageType,
 };
 
-mod index {
+pub mod index {
     pub const DATA: usize = 3;
     pub const DATA_END: usize = DATA + 2;
 }


### PR DESCRIPTION
External users may find use in the `index` modules for the various message types.

Exposes all `index` modules as public.