### PR TITLE
hardware: change cashbox removed to warning state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebds"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "Messages and related types for implementing the EBDS serial communication protocol"

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -122,7 +122,7 @@ impl From<DeviceState> for HardwareState {
 impl From<DeviceStateFlags> for HardwareState {
     fn from(dev_state: DeviceStateFlags) -> Self {
         match dev_state {
-            DeviceStateFlags::Disconnected | DeviceStateFlags::CashBoxRemoved => Self::Missing,
+            DeviceStateFlags::Disconnected | DeviceStateFlags::CashBoxRemoved => Self::Warning,
             DeviceStateFlags::PowerUp
             | DeviceStateFlags::Initialize
             | DeviceStateFlags::Download


### PR DESCRIPTION
Changes the `HardwareState` conversion to `HardwareState::Warn` for a disconnected/cashbox removed device state change.

Bumps version to account for `HardwareState` conversion change.