### PR TITLE
version: bump to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebds"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "Messages and related types for implementing the EBDS serial communication protocol"


### PR DESCRIPTION
Bumps the version to include changes to the currency type, making it incompatible with all previous minor-version releases.