### PR TITLE
version: bump to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebds"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "Messages and related types for implementing the EBDS serial communication protocol"


### PR DESCRIPTION
Bumps release version to `0.2.1` to include formatting changes for `DeviceStateFlags`.