### PR TITLE
fixup/traits: add derive traits, version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebds"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "Messages and related types for implementing the EBDS serial communication protocol"

--- a/src/advanced_bookmark_mode/command.rs
+++ b/src/advanced_bookmark_mode/command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bool_enum, impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
+    bool_enum, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
     len::ADVANCED_BOOKMARK_MODE_COMMAND, ExtendedCommand, ExtendedCommandOps, MessageOps,
     MessageType,
 };
@@ -56,7 +56,7 @@ bool_enum!(
 ///
 /// The Status byte tells the device to enable (0x01) or disable (0x00) the mode.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct AdvancedBookmarkModeCommand {
     buf: [u8; ADVANCED_BOOKMARK_MODE_COMMAND],
 }
@@ -86,7 +86,6 @@ impl AdvancedBookmarkModeCommand {
     }
 }
 
-impl_default!(AdvancedBookmarkModeCommand);
 impl_message_ops!(AdvancedBookmarkModeCommand);
 impl_extended_ops!(AdvancedBookmarkModeCommand);
 impl_omnibus_extended_command!(AdvancedBookmarkModeCommand);

--- a/src/advanced_bookmark_mode/reply.rs
+++ b/src/advanced_bookmark_mode/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    bool_enum, impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
+    bool_enum, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
     len::ADVANCED_BOOKMARK_MODE_REPLY, ExtendedCommand, ExtendedCommandOps, MessageOps,
     MessageType, OmnibusReplyOps,
 };
@@ -37,7 +37,7 @@ May also indicate the device was busy (NAKs when stacking or powering up).
 /// When the device stacks a document in this mode, the Standard Omnibus Reply (section 7.1.2) is
 /// reported with the stacked bit set and no value reported in data byte 2.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct AdvancedBookmarkModeReply {
     buf: [u8; ADVANCED_BOOKMARK_MODE_REPLY],
 }
@@ -67,7 +67,6 @@ impl AdvancedBookmarkModeReply {
     }
 }
 
-impl_default!(AdvancedBookmarkModeReply);
 impl_message_ops!(AdvancedBookmarkModeReply);
 impl_omnibus_extended_reply!(AdvancedBookmarkModeReply);
 impl_extended_ops!(AdvancedBookmarkModeReply);

--- a/src/banknote.rs
+++ b/src/banknote.rs
@@ -9,7 +9,7 @@ pub type ISOCode = Currency;
 
 /// A three character ASCII coded decimal value
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BaseValue(u16);
 
 impl BaseValue {
@@ -75,8 +75,9 @@ impl<const N: usize> From<&[u8; N]> for BaseValue {
 /// An ASCII  coded sign value for the Exponent.
 /// This field is either a “+” or a “-“
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Sign {
+    #[default]
     Positive,
     Negative,
 }
@@ -117,8 +118,14 @@ pub struct Exponent(u8);
 impl Exponent {
     pub const LEN: usize = 2;
 
-    pub const fn default() -> Self {
+    pub const fn new() -> Self {
         Self(1)
+    }
+}
+
+impl Default for Exponent {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -190,8 +197,9 @@ impl<const N: usize> From<&[u8; N]> for Exponent {
 /// Extended orientation bit is set in device
 /// capabilities map.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum BanknoteOrientation {
+    #[default]
     RightEdgeFaceUp = 0x00,
     RightEdgeFaceDown = 0x01,
     LeftEdgeFaceUp = 0x02,
@@ -251,13 +259,13 @@ impl fmt::Display for BanknoteOrientation {
 macro_rules! ascii_tuple_struct {
     ($name:ident, $base:tt, $doc:tt) => {
         #[doc = $doc]
-        #[derive(Clone, Copy, Debug, PartialEq)]
+        #[derive(Clone, Copy, Debug, Default, PartialEq)]
         pub struct $name($base);
 
         impl $name {
             pub const LEN: usize = std::mem::size_of::<$base>();
 
-            pub const fn default() -> Self {
+            pub const fn new() -> Self {
                 Self(0)
             }
 
@@ -332,8 +340,9 @@ ascii_tuple_struct!(
 "
 );
 
+/// Represents how the BAU device classifies a [Banknote].
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum BanknoteClassification {
     /// Sent for any the following:
     ///
@@ -341,6 +350,7 @@ pub enum BanknoteClassification {
     /// - In response to a note escrowed or stacked event while device is in extended note mode and classification is
     ///     - Supported by the device but disabled.
     ///     - NOT supported by the device.
+    #[default]
     DisabledOrNotSupported = 0x00,
     /// Class 1 (unidentified banknote)
     Unidentified = 0x01,
@@ -353,7 +363,7 @@ pub enum BanknoteClassification {
 }
 
 impl BanknoteClassification {
-    pub const fn default() -> Self {
+    pub const fn new() -> Self {
         Self::DisabledOrNotSupported
     }
 }
@@ -400,7 +410,7 @@ impl fmt::Display for BanknoteClassification {
 
 /// The banknote value
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Banknote {
     /// The banknote value.
     pub(crate) value: f32,
@@ -419,6 +429,7 @@ pub struct Banknote {
 }
 
 impl Banknote {
+    /// Creates a new [Banknote] with the provided parameters.
     pub const fn new(
         value: f32,
         iso_code: ISOCode,
@@ -439,15 +450,16 @@ impl Banknote {
         }
     }
 
-    pub const fn default() -> Self {
+    /// Creates a new null [Banknote].
+    pub const fn null() -> Self {
         Self {
-            value: 0f32,
+            value: 0.0,
             iso_code: ISOCode::new(),
-            note_type: NoteType::default(),
-            note_series: NoteSeries::default(),
-            note_compatibility: NoteCompatibility::default(),
-            note_version: NoteVersion::default(),
-            banknote_classification: BanknoteClassification::default(),
+            note_type: NoteType::new(),
+            note_series: NoteSeries::new(),
+            note_compatibility: NoteCompatibility::new(),
+            note_version: NoteVersion::new(),
+            banknote_classification: BanknoteClassification::new(),
         }
     }
 
@@ -546,7 +558,7 @@ impl fmt::Display for Banknote {
 
 /// Extended note table item
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct NoteTableItem {
     pub(crate) note_index: usize,
     pub(crate) banknote: Banknote,
@@ -558,14 +570,6 @@ impl NoteTableItem {
         Self {
             note_index,
             banknote,
-        }
-    }
-
-    /// Creates a default (null) [NoteTableItem]
-    pub const fn default() -> Self {
-        Self {
-            note_index: 0,
-            banknote: Banknote::default(),
         }
     }
 

--- a/src/clear_audit_data/reply.rs
+++ b/src/clear_audit_data/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    bool_enum, impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
+    bool_enum, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
     len::{CLEAR_AUDIT_DATA_REQUEST_ACK, CLEAR_AUDIT_DATA_REQUEST_RESULTS},
     ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType, OmnibusReplyOps,
 };
@@ -47,7 +47,8 @@ pub mod index {
 /// device will NAK all Clear Audit Data Request
 /// * Device is in calibration mode.
 /// * The device is currently servicing another type 7 message request.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ClearAuditDataRequestAck {
     buf: [u8; CLEAR_AUDIT_DATA_REQUEST_ACK],
 }
@@ -79,7 +80,6 @@ impl ClearAuditDataRequestAck {
     }
 }
 
-impl_default!(ClearAuditDataRequestAck);
 impl_message_ops!(ClearAuditDataRequestAck);
 impl_omnibus_extended_reply!(ClearAuditDataRequestAck);
 impl_extended_ops!(ClearAuditDataRequestAck);
@@ -119,7 +119,8 @@ impl fmt::Display for ClearAuditDataRequestAck {
 /// |:------|:----:|:----:|:----:|:-------:|:------:|:------:|:------:|:------:|:------:|:------:|:---------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3       | 4      | 5      | 6      | 7      | 8      | 9      | 10        | 11   | 12  |
 /// | Value | 0x02 | 0x0D | 0x7n | 0x1D    | nn     | nn     | nn     | nn     | nn     | nn     | 0x00/01   | 0x03 | zz  |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ClearAuditDataRequestResults {
     buf: [u8; CLEAR_AUDIT_DATA_REQUEST_RESULTS],
 }
@@ -143,7 +144,6 @@ impl ClearAuditDataRequestResults {
     }
 }
 
-impl_default!(ClearAuditDataRequestResults);
 impl_message_ops!(ClearAuditDataRequestResults);
 impl_omnibus_extended_reply!(ClearAuditDataRequestResults);
 impl_extended_ops!(ClearAuditDataRequestResults);

--- a/src/clear_audit_data/request.rs
+++ b/src/clear_audit_data/request.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
+    impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
     len::CLEAR_AUDIT_DATA_REQUEST, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
 };
 
@@ -19,6 +19,8 @@ use crate::{
 ///
 /// Since the command needs to clear large sections of memory, the command may take a few seconds to
 /// complete.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ClearAuditDataRequest {
     buf: [u8; CLEAR_AUDIT_DATA_REQUEST],
 }
@@ -37,7 +39,6 @@ impl ClearAuditDataRequest {
     }
 }
 
-impl_default!(ClearAuditDataRequest);
 impl_message_ops!(ClearAuditDataRequest);
 impl_extended_ops!(ClearAuditDataRequest);
 impl_omnibus_extended_command!(ClearAuditDataRequest);

--- a/src/denomination.rs
+++ b/src/denomination.rs
@@ -6,8 +6,9 @@ use std::fmt;
 
 /// Cash denominations
 #[repr(u32)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Denomination {
+    #[default]
     Zero = 0,
     One = 1,
     Two = 2,
@@ -96,7 +97,7 @@ impl From<Denomination> for u32 {
 
 bitfield! {
     /// Enable/disable note denominations while in base note mode
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct StandardDenomination(u8);
     u8;
     pub one, set_one: 0;
@@ -224,7 +225,7 @@ impl From<StandardDenominationFlag> for StandardDenomination {
 
 /// Bit flags for [StandardDenomination]s.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum StandardDenominationFlag {
     Denom1 = 0b000_0001,
     Denom2 = 0b000_0010,
@@ -233,11 +234,13 @@ pub enum StandardDenominationFlag {
     Denom5 = 0b001_0000,
     Denom6 = 0b010_0000,
     Denom7 = 0b100_0000,
+    #[default]
     Zero = 0b000_0000,
 }
 
 impl StandardDenominationFlag {
-    pub const fn default() -> Self {
+    /// Creates a new [StandardDenominationFlag].
+    pub const fn new() -> Self {
         Self::Zero
     }
 }

--- a/src/extended_note_inhibits/command.rs
+++ b/src/extended_note_inhibits/command.rs
@@ -23,7 +23,7 @@ pub mod index {
 
 bitfield! {
     /// Represents enabled notes in the extended note table.
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct EnableNote(u8);
     u8;
     pub note1, set_note1: 0;
@@ -179,6 +179,7 @@ impl From<EnableNote> for u8 {
 /// | Enable 19 | -        | -        | -        | -        | -        | Note 128 | Note 127 |
 ///
 /// If the bit equals 1 then the note is enabled.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SetExtendedNoteInhibits<const M: usize, const N: usize> {
     buf: [u8; M],
 }

--- a/src/extended_note_inhibits/reply.rs
+++ b/src/extended_note_inhibits/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_extended_reply_ops, impl_message_ops, impl_omnibus_extended_reply,
+    impl_extended_reply_ops, impl_message_ops, impl_omnibus_extended_reply,
     len::EXTENDED_NOTE_INHIBITS_REPLY_ALT, ExtendedCommand, ExtendedReplyOps, MessageOps,
     MessageType, OmnibusReply,
 };
@@ -31,7 +31,7 @@ pub type ExtendedNoteInhibitsReply = OmnibusReply;
 /// **WARNING** In order to avoid possible confusion processing the extended note data, this command should
 /// only be sent when the device is in the idle state.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ExtendedNoteInhibitsReplyAlt {
     buf: [u8; EXTENDED_NOTE_INHIBITS_REPLY_ALT],
 }
@@ -51,7 +51,6 @@ impl ExtendedNoteInhibitsReplyAlt {
     }
 }
 
-impl_default!(ExtendedNoteInhibitsReplyAlt);
 impl_message_ops!(ExtendedNoteInhibitsReplyAlt);
 impl_omnibus_extended_reply!(ExtendedNoteInhibitsReplyAlt);
 impl_extended_reply_ops!(ExtendedNoteInhibitsReplyAlt);

--- a/src/extended_note_specification/query.rs
+++ b/src/extended_note_specification/query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
+    impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
     len::QUERY_EXTENDED_NOTE_SPECIFICATION, ExtendedCommand, ExtendedCommandOps,
     ExtendedNoteReporting, MessageOps, MessageType, OmnibusCommandOps,
 };
@@ -23,7 +23,8 @@ pub mod index {
 ///
 /// The first extended data byte is the Index. This index value starts at `1` and represents the index of the
 /// extended note table data in the device.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryExtendedNoteSpecification {
     buf: [u8; QUERY_EXTENDED_NOTE_SPECIFICATION],
 }
@@ -54,7 +55,6 @@ impl QueryExtendedNoteSpecification {
     }
 }
 
-impl_default!(QueryExtendedNoteSpecification);
 impl_message_ops!(QueryExtendedNoteSpecification);
 impl_extended_ops!(QueryExtendedNoteSpecification);
 impl_omnibus_extended_command!(QueryExtendedNoteSpecification);

--- a/src/extended_note_specification/reply.rs
+++ b/src/extended_note_specification/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    banknote::*, impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
+    banknote::*, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
     len::EXTENDED_NOTE_REPLY, status::*, ExtendedCommand, ExtendedCommandOps, MessageOps,
     MessageType, OmnibusReplyOps,
 };
@@ -118,7 +118,7 @@ pub mod index {
 /// | Version                 | 14          | An ASCII letter that documents the version of the note's recognition criteria.<br>This corresponds to the data in the variant identity card. | "A" |
 /// | Banknote Classification | 15          | 0x00 = Sent for any of the following:<ul><li>In response to a Host Query Extended Note Specification Command (i.e. host requests a note table element).</li><li>In response to a note escrowed or stacked event while device is in extended note mode and classification is:<ul><li>Supported by the device but disabled.</li><li>NOT supported by the device.</li></ul></li></ul><br>**SC Adv Classification**<br>**SCR Classification**<br>0x01 = Class 1 (unidentified banknote)<br>0x02 = Class 2 (suspected counterfeit)<br>0x03 = Class 3 (suspected zero value note)<br>0x04 = Class 4 (genuine banknote) | 0x00 |
 /// | Reserved                | 16..17      | Bytes reserved for future use                         | N/A                             |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ExtendedNoteReply {
     buf: [u8; EXTENDED_NOTE_REPLY],
 }
@@ -212,7 +212,6 @@ impl ExtendedNoteReply {
     }
 }
 
-impl_default!(ExtendedNoteReply);
 impl_message_ops!(ExtendedNoteReply);
 impl_extended_ops!(ExtendedNoteReply);
 impl_omnibus_extended_reply!(ExtendedNoteReply);

--- a/src/flash_download/baud_rate.rs
+++ b/src/flash_download/baud_rate.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply,
+    impl_message_ops, impl_omnibus_nop_reply,
     len::{BAUD_CHANGE_REPLY, BAUD_CHANGE_REQUEST},
     MessageOps, MessageType,
 };
@@ -15,8 +15,9 @@ pub mod index {
 
 /// Represents the acceptable values for host-device serial baud rates.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum BaudRate {
+    #[default]
     _9600 = 0x01,
     _19200 = 0x02,
     _38400 = 0x03,
@@ -126,7 +127,7 @@ impl fmt::Display for BaudRate {
 /// respond to the baud rate change request. This means the host will be required to perform the download
 /// using the original algorithm.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BaudRateChangeRequest {
     buf: [u8; BAUD_CHANGE_REQUEST],
 }
@@ -162,7 +163,6 @@ impl BaudRateChangeRequest {
     }
 }
 
-impl_default!(BaudRateChangeRequest);
 impl_message_ops!(BaudRateChangeRequest);
 
 impl fmt::Display for BaudRateChangeRequest {
@@ -202,7 +202,7 @@ impl fmt::Display for BaudRateChangeRequest {
 /// respond to the baud rate change request. This means the host will be required to perform the download
 /// using the original algorithm.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BaudRateChangeReply {
     buf: [u8; BAUD_CHANGE_REPLY],
 }
@@ -238,7 +238,6 @@ impl BaudRateChangeReply {
     }
 }
 
-impl_default!(BaudRateChangeReply);
 impl_message_ops!(BaudRateChangeReply);
 impl_omnibus_nop_reply!(BaudRateChangeReply);
 

--- a/src/flash_download/reply_7bit.rs
+++ b/src/flash_download/reply_7bit.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::FLASH_DOWNLOAD_REPLY_7BIT,
-    seven_bit_u16, u16_seven_bit, MessageOps, MessageType,
+    impl_message_ops, impl_omnibus_nop_reply, len::FLASH_DOWNLOAD_REPLY_7BIT, seven_bit_u16,
+    u16_seven_bit, MessageOps, MessageType,
 };
 
 use super::FlashDownloadReply;
@@ -45,7 +45,7 @@ pub mod index {
 /// | Byte  | 0    | 1    | 2    | 3         | 4         | 5         | 6         | 7    | 8   |
 /// | Value | 0x02 | 0x09 | 0x5n | 0x0n      | 0x0n      | 0x0n      | 0x0n      | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct FlashDownloadReply7bit {
     buf: [u8; FLASH_DOWNLOAD_REPLY_7BIT],
 }
@@ -64,7 +64,6 @@ impl FlashDownloadReply7bit {
     }
 }
 
-impl_default!(FlashDownloadReply7bit);
 impl_message_ops!(FlashDownloadReply7bit);
 impl_omnibus_nop_reply!(FlashDownloadReply7bit);
 

--- a/src/flash_download/reply_8bit.rs
+++ b/src/flash_download/reply_8bit.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::FLASH_DOWNLOAD_REPLY_8BIT,
-    MessageOps, MessageType,
+    impl_message_ops, impl_omnibus_nop_reply, len::FLASH_DOWNLOAD_REPLY_8BIT, MessageOps,
+    MessageType,
 };
 
 use super::FlashDownloadReply;
@@ -32,7 +32,7 @@ pub mod index {
 /// | Byte  | 0    | 1    | 2    | 3         | 4         | 5    | 6   |
 /// | Value | 0x02 | 0x07 | 0x5n | 0xnn      | 0xnn      | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct FlashDownloadReply8bit {
     buf: [u8; FLASH_DOWNLOAD_REPLY_8BIT],
 }
@@ -51,7 +51,6 @@ impl FlashDownloadReply8bit {
     }
 }
 
-impl_default!(FlashDownloadReply8bit);
 impl_message_ops!(FlashDownloadReply8bit);
 impl_omnibus_nop_reply!(FlashDownloadReply8bit);
 

--- a/src/flash_download/start_download/command.rs
+++ b/src/flash_download/start_download/command.rs
@@ -1,6 +1,5 @@
 use crate::{
-    impl_default, impl_message_ops, len::START_DOWNLOAD_COMMAND, ExtendedNoteReporting, MessageOps,
-    MessageType,
+    impl_message_ops, len::START_DOWNLOAD_COMMAND, ExtendedNoteReporting, MessageOps, MessageType,
 };
 
 pub mod index {
@@ -17,7 +16,7 @@ pub mod index {
 /// |------|------|------|-------|-------|---------|------|------|
 /// | 0x02 | 0x08 | 0x5n | 0x00  | 0x00  | 0x00/10 | 0x03 | zz   |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct StartDownloadCommand {
     buf: [u8; START_DOWNLOAD_COMMAND],
 }
@@ -49,7 +48,6 @@ impl StartDownloadCommand {
     }
 }
 
-impl_default!(StartDownloadCommand);
 impl_message_ops!(StartDownloadCommand);
 
 #[cfg(test)]

--- a/src/flash_download/start_download/reply.rs
+++ b/src/flash_download/start_download/reply.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    bool_enum, impl_default, impl_message_ops, impl_omnibus_nop_reply, len::START_DOWNLOAD_REPLY,
-    MessageOps, MessageType,
+    bool_enum, impl_message_ops, impl_omnibus_nop_reply, len::START_DOWNLOAD_REPLY, MessageOps,
+    MessageType,
 };
 
 pub mod index {
@@ -25,7 +25,7 @@ bool_enum!(
 /// |------|------|------|-------|-------|-------|---------|-------|-------|------|------|
 /// | 0x02 | 0x0B | 0x5n | nn    | nn    | nn    | 0x00/02 | nn    | nn    | 0x03 | zz   |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct StartDownloadReply {
     buf: [u8; START_DOWNLOAD_REPLY],
 }
@@ -59,7 +59,6 @@ impl StartDownloadReply {
     }
 }
 
-impl_default!(StartDownloadReply);
 impl_message_ops!(StartDownloadReply);
 impl_omnibus_nop_reply!(StartDownloadReply);
 

--- a/src/note_retrieved/command.rs
+++ b/src/note_retrieved/command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bool_enum, impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
+    bool_enum, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
     len::NOTE_RETRIEVED_COMMAND, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
 };
 
@@ -34,7 +34,7 @@ bool_enum!(
 /// |:------|:----:|:----:|:----:|:-------:|:------:|:------:|:------:|:-------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3       | 4      | 5      | 6      | 7       | 8    | 9   |
 /// | Value | 0x02 | 0x0A | 0x7n | 0x0B    | nn     | nn     | nn     | 0x00/01 | 0x03 | zz  |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct NoteRetrievedCommand {
     buf: [u8; NOTE_RETRIEVED_COMMAND],
 }
@@ -63,7 +63,6 @@ impl NoteRetrievedCommand {
     }
 }
 
-impl_default!(NoteRetrievedCommand);
 impl_message_ops!(NoteRetrievedCommand);
 impl_omnibus_extended_command!(NoteRetrievedCommand);
 impl_extended_ops!(NoteRetrievedCommand);

--- a/src/note_retrieved/reply.rs
+++ b/src/note_retrieved/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    bool_enum, impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
+    bool_enum, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
     len::{NOTE_RETRIEVED_EVENT, NOTE_RETRIEVED_REPLY},
     ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType, OmnibusReplyOps,
 };
@@ -35,7 +35,7 @@ pub mod index {
 /// |:------|:----:|:----:|:----:|:-------:|:------:|:------:|:------:|:------:|:------:|:------:|:-------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3       | 4      | 5      | 6      | 7      | 8      | 9      | 10      | 11   | 12  |
 /// | Value | 0x02 | 0x0D | 0x7n | 0x0B    | nn     | nn     | nn     | nn     | nn     | nn     | 0x01/00 | 0x03 | zz  |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct NoteRetrievedReply {
     buf: [u8; NOTE_RETRIEVED_REPLY],
 }
@@ -62,7 +62,6 @@ impl NoteRetrievedReply {
     }
 }
 
-impl_default!(NoteRetrievedReply);
 impl_message_ops!(NoteRetrievedReply);
 impl_omnibus_extended_reply!(NoteRetrievedReply);
 impl_extended_ops!(NoteRetrievedReply);
@@ -99,7 +98,7 @@ impl fmt::Display for NoteRetrievedReply {
 /// | Value | 0x02 | 0x0D | 0x7n | 0x0B    | nn     | nn     | nn     | nn     | nn     | nn     | 0x7F  | 0x03 | zz  |
 ///
 /// The `0x7F` for the `Event byte signifies that the note has been removed by the user.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct NoteRetrievedEvent {
     buf: [u8; NOTE_RETRIEVED_EVENT],
 }
@@ -123,7 +122,6 @@ impl NoteRetrievedEvent {
     }
 }
 
-impl_default!(NoteRetrievedEvent);
 impl_message_ops!(NoteRetrievedEvent);
 impl_omnibus_extended_reply!(NoteRetrievedEvent);
 impl_extended_ops!(NoteRetrievedEvent);

--- a/src/omnibus/command.rs
+++ b/src/omnibus/command.rs
@@ -1,7 +1,7 @@
 use bitfield::bitfield;
 
 use crate::{
-    bool_enum, impl_default, impl_message_ops, impl_omnibus_command_ops,
+    bool_enum, impl_message_ops, impl_omnibus_command_ops,
     len::{FLASH_DATA_PACKET, OMNIBUS_COMMAND},
     FlashDownloadMessage, MessageOps, MessageType, StandardDenomination,
 };
@@ -20,7 +20,7 @@ bitfield! {
     /// * [EscrowMode]: bit 4
     /// * [DocumentStack]: bit 5
     /// * [DocumentReturn]: bit 6
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct OperationalMode(u8);
     u8;
     /// This field controls the acceptance of bank notes based on the orientation of those
@@ -65,13 +65,14 @@ impl From<u8> for OperationalMode {
 
 /// Controls which bill orientation is accepted
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum OrientationControl {
     /// Accept notes fed right edge first, face up only
     OneWay = 0b00,
     /// Accept notes face up only
     TwoWay = 0b01,
     /// Accept notes fed any way
+    #[default]
     FourWay = 0b10,
 }
 
@@ -153,7 +154,7 @@ bitfield! {
     /// * [PowerUp]: bits 2..3
     /// * [ExtendedNoteReporting]: bit 4
     /// * [ExtendedCouponReporting]: bit 5
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Configuration(u8);
     u8;
     pub no_push, set_no_push: 0;
@@ -217,9 +218,10 @@ bool_enum!(
 /// Values that represent acceptor device power up  policy.
 /// That define device behavior on power up with bill in trace.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum PowerUp {
     /// Post - Escrow : The procedure will complete and the document will be stacked. However, no value will be reported to the host.
+    #[default]
     A = 0b00,
     /// Escrow : The device will go out of order and hold the document at the escrow position.
     /// Post - Escrow : The procedure will complete and the document will be stacked.
@@ -326,7 +328,7 @@ mod bitmask {
 /// For more detailed information about the meaning of the data fields, see the EBDS Protocol
 /// Specification: sections 7.1.1.[1-3].
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct OmnibusCommand {
     buf: [u8; OMNIBUS_COMMAND],
 }
@@ -486,7 +488,6 @@ pub trait OmnibusCommandOps: MessageOps {
     }
 }
 
-impl_default!(OmnibusCommand);
 impl_message_ops!(OmnibusCommand);
 impl_omnibus_command_ops!(OmnibusCommand);
 

--- a/src/omnibus/reply.rs
+++ b/src/omnibus/reply.rs
@@ -2,14 +2,13 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    banknote::*, cash::CurrencyDenomination, impl_default, impl_from_for_omnibus_reply,
-    impl_message_ops, impl_omnibus_reply_ops, len::OMNIBUS_REPLY, status::*,
-    AdvancedBookmarkModeReply, ClearAuditDataRequestAck, ClearAuditDataRequestResults,
-    ExtendedNoteInhibitsReplyAlt, ExtendedNoteReply, MessageOps, MessageType, NoteRetrievedEvent,
-    NoteRetrievedReply, QueryApplicationIdReply, QueryApplicationPartNumberReply,
-    QueryBootPartNumberReply, QueryDeviceCapabilitiesReply, QueryValueTableReply,
-    QueryVariantIdReply, QueryVariantNameReply, QueryVariantPartNumberReply, SetEscrowTimeoutReply,
-    StandardDenomination,
+    banknote::*, cash::CurrencyDenomination, impl_from_for_omnibus_reply, impl_message_ops,
+    impl_omnibus_reply_ops, len::OMNIBUS_REPLY, status::*, AdvancedBookmarkModeReply,
+    ClearAuditDataRequestAck, ClearAuditDataRequestResults, ExtendedNoteInhibitsReplyAlt,
+    ExtendedNoteReply, MessageOps, MessageType, NoteRetrievedEvent, NoteRetrievedReply,
+    QueryApplicationIdReply, QueryApplicationPartNumberReply, QueryBootPartNumberReply,
+    QueryDeviceCapabilitiesReply, QueryValueTableReply, QueryVariantIdReply, QueryVariantNameReply,
+    QueryVariantPartNumberReply, SetEscrowTimeoutReply, StandardDenomination,
 };
 
 pub mod index {
@@ -53,7 +52,7 @@ pub mod index {
 /// * Data byte 3: [MiscDeviceState]
 /// * Data byte 4: [ModelNumber]
 /// * Data byte 5: [CodeRevision]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OmnibusReply {
     buf: [u8; OMNIBUS_REPLY],
@@ -480,7 +479,6 @@ pub trait OmnibusReplyOps: MessageOps {
     }
 }
 
-impl_default!(OmnibusReply);
 impl_message_ops!(OmnibusReply);
 impl_omnibus_reply_ops!(OmnibusReply);
 

--- a/src/query_application_id/command.rs
+++ b/src/query_application_id/command.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::QUERY_APPLICATION_ID_COMMAND, AuxCommand,
-    AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::QUERY_APPLICATION_ID_COMMAND, AuxCommand, AuxCommandOps,
+    MessageOps, MessageType,
 };
 
 /// Query Application ID - Command (Subtype 0x0E)
@@ -23,7 +23,7 @@ use crate::{
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x0E    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryApplicationIdCommand {
     buf: [u8; QUERY_APPLICATION_ID_COMMAND],
 }
@@ -42,7 +42,6 @@ impl QueryApplicationIdCommand {
     }
 }
 
-impl_default!(QueryApplicationIdCommand);
 impl_message_ops!(QueryApplicationIdCommand);
 impl_aux_ops!(QueryApplicationIdCommand);
 

--- a/src/query_application_id/reply.rs
+++ b/src/query_application_id/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::QUERY_APPLICATION_ID_REPLY,
+    impl_message_ops, impl_omnibus_nop_reply, len::QUERY_APPLICATION_ID_REPLY,
     ApplicationPartNumber, MessageOps, MessageType, PartVersion, ProjectNumber,
 };
 
@@ -29,7 +29,7 @@ pub mod index {
 ///
 /// See [ProjectNumber](crate::ProjectNumber) for formatting details.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryApplicationIdReply {
     buf: [u8; QUERY_APPLICATION_ID_REPLY],
 }
@@ -67,7 +67,6 @@ impl QueryApplicationIdReply {
     }
 }
 
-impl_default!(QueryApplicationIdReply);
 impl_message_ops!(QueryApplicationIdReply);
 impl_omnibus_nop_reply!(QueryApplicationIdReply);
 

--- a/src/query_application_part_number/command.rs
+++ b/src/query_application_part_number/command.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::QUERY_APPLICATION_PART_NUMBER_COMMAND,
-    AuxCommand, AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::QUERY_APPLICATION_PART_NUMBER_COMMAND, AuxCommand,
+    AuxCommandOps, MessageOps, MessageType,
 };
 
 /// Query Application Part Number - Command (Subtype 0x07)
@@ -15,7 +15,7 @@ use crate::{
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x07    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryApplicationPartNumberCommand {
     buf: [u8; QUERY_APPLICATION_PART_NUMBER_COMMAND],
 }
@@ -34,7 +34,6 @@ impl QueryApplicationPartNumberCommand {
     }
 }
 
-impl_default!(QueryApplicationPartNumberCommand);
 impl_message_ops!(QueryApplicationPartNumberCommand);
 impl_aux_ops!(QueryApplicationPartNumberCommand);
 

--- a/src/query_application_part_number/reply.rs
+++ b/src/query_application_part_number/reply.rs
@@ -2,9 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply,
-    len::QUERY_APPLICATION_PART_NUMBER_REPLY, ApplicationPartNumber, MessageOps, MessageType,
-    PartVersion, ProjectNumber,
+    impl_message_ops, impl_omnibus_nop_reply, len::QUERY_APPLICATION_PART_NUMBER_REPLY,
+    ApplicationPartNumber, MessageOps, MessageType, PartVersion, ProjectNumber,
 };
 
 pub mod index {
@@ -30,7 +29,7 @@ pub mod index {
 ///
 /// See [ProjectNumber](crate::ProjectNumber) for formatting details.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryApplicationPartNumberReply {
     buf: [u8; QUERY_APPLICATION_PART_NUMBER_REPLY],
 }
@@ -68,7 +67,6 @@ impl QueryApplicationPartNumberReply {
     }
 }
 
-impl_default!(QueryApplicationPartNumberReply);
 impl_message_ops!(QueryApplicationPartNumberReply);
 impl_omnibus_nop_reply!(QueryApplicationPartNumberReply);
 

--- a/src/query_boot_part_number/command.rs
+++ b/src/query_boot_part_number/command.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::QUERY_BOOT_PART_NUMBER_COMMAND, AuxCommand,
-    AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::QUERY_BOOT_PART_NUMBER_COMMAND, AuxCommand, AuxCommandOps,
+    MessageOps, MessageType,
 };
 
 /// Query Boot Part Number - Command (Subtype 0x06)
@@ -15,7 +15,7 @@ use crate::{
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x06    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryBootPartNumberCommand {
     buf: [u8; QUERY_BOOT_PART_NUMBER_COMMAND],
 }
@@ -34,7 +34,6 @@ impl QueryBootPartNumberCommand {
     }
 }
 
-impl_default!(QueryBootPartNumberCommand);
 impl_message_ops!(QueryBootPartNumberCommand);
 impl_aux_ops!(QueryBootPartNumberCommand);
 

--- a/src/query_boot_part_number/reply.rs
+++ b/src/query_boot_part_number/reply.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::QUERY_BOOT_PART_NUMBER_REPLY,
-    BootPartNumber, MessageOps, MessageType, PartVersion, ProjectNumber,
+    impl_message_ops, impl_omnibus_nop_reply, len::QUERY_BOOT_PART_NUMBER_REPLY, BootPartNumber,
+    MessageOps, MessageType, PartVersion, ProjectNumber,
 };
 
 pub mod index {
@@ -29,7 +29,7 @@ pub mod index {
 ///
 /// See [ProjectNumber](crate::ProjectNumber) for formatting details.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryBootPartNumberReply {
     buf: [u8; QUERY_BOOT_PART_NUMBER_REPLY],
 }
@@ -67,7 +67,6 @@ impl QueryBootPartNumberReply {
     }
 }
 
-impl_default!(QueryBootPartNumberReply);
 impl_message_ops!(QueryBootPartNumberReply);
 impl_omnibus_nop_reply!(QueryBootPartNumberReply);
 

--- a/src/query_device_capabilities/command.rs
+++ b/src/query_device_capabilities/command.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, impl_omnibus_command_ops,
+    impl_aux_ops, impl_message_ops, impl_omnibus_command_ops,
     len::QUERY_DEVICE_CAPABILITIES_COMMAND, AuxCommand, AuxCommandOps, MessageOps, MessageType,
 };
 
@@ -18,7 +18,8 @@ use crate::{
 /// |:------|:----:|:----:|:----:|:------:|:------:|:-------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x0D    | 0x03 | zz  |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryDeviceCapabilitiesCommand {
     buf: [u8; QUERY_DEVICE_CAPABILITIES_COMMAND],
 }
@@ -38,7 +39,6 @@ impl QueryDeviceCapabilitiesCommand {
     }
 }
 
-impl_default!(QueryDeviceCapabilitiesCommand);
 impl_message_ops!(QueryDeviceCapabilitiesCommand);
 impl_aux_ops!(QueryDeviceCapabilitiesCommand);
 impl_omnibus_command_ops!(QueryDeviceCapabilitiesCommand);

--- a/src/query_device_capabilities/reply.rs
+++ b/src/query_device_capabilities/reply.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::QUERY_DEVICE_CAPABILITIES_REPLY,
-    MessageOps, MessageType,
+    impl_message_ops, impl_omnibus_nop_reply, len::QUERY_DEVICE_CAPABILITIES_REPLY, MessageOps,
+    MessageType,
 };
 
 pub mod index {
@@ -17,7 +17,7 @@ pub mod index {
 
 bitfield! {
     /// First set of device capabilties
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Cap0(u8);
     u8;
     /// **OBSOLETE** Extended PUP mode is supported.
@@ -78,7 +78,7 @@ impl From<Cap0> for u8 {
 
 bitfield! {
     /// Second set of device capabilties
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Cap1(u8);
     u8;
     /// Note Retrieved is supported.
@@ -135,7 +135,7 @@ bitfield! {
     ///
     /// Note: **SCR Classification** If banknote classification is supported (i.e. Cap Byte 3, bit 1 is set), all denomination
     /// recycling bits will be set to 0.
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Cap2(u8);
     u8;
     /// 1 Denomination recycling is supported.
@@ -209,7 +209,7 @@ impl From<Cap2> for u8 {
 
 bitfield! {
     /// Fourth set of device capabilties
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Cap3(u8);
     u8;
     /// Customer Configuration Options Set/Query (Msg 6 Subtypes 0x25 and 0x26) are supported.
@@ -249,7 +249,7 @@ impl From<Cap3> for u8 {
 
 bitfield! {
     /// Fifth set of device capabilties
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Cap4(u8);
     u8;
     /// RFU
@@ -282,7 +282,7 @@ impl From<Cap4> for u8 {
 
 bitfield! {
     /// Sixth set of device capabilties
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Cap5(u8);
     u8;
     /// RFU
@@ -333,7 +333,8 @@ impl From<Cap5> for u8 {
 /// * [Cap3]
 /// * [Cap4] - RFU
 /// * [Cap5] - RFU
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryDeviceCapabilitiesReply {
     buf: [u8; QUERY_DEVICE_CAPABILITIES_REPLY],
 }
@@ -382,7 +383,6 @@ impl QueryDeviceCapabilitiesReply {
     }
 }
 
-impl_default!(QueryDeviceCapabilitiesReply);
 impl_message_ops!(QueryDeviceCapabilitiesReply);
 impl_omnibus_nop_reply!(QueryDeviceCapabilitiesReply);
 

--- a/src/query_software_crc/command.rs
+++ b/src/query_software_crc/command.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::QUERY_SOFTWARE_CRC_COMMAND, AuxCommand,
-    AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::QUERY_SOFTWARE_CRC_COMMAND, AuxCommand, AuxCommandOps,
+    MessageOps, MessageType,
 };
 
 /// Query Software CRC - Command (Subtype 0x00)
@@ -17,7 +17,7 @@ use crate::{
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x00    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QuerySoftwareCrcCommand {
     buf: [u8; QUERY_SOFTWARE_CRC_COMMAND],
 }
@@ -36,6 +36,5 @@ impl QuerySoftwareCrcCommand {
     }
 }
 
-impl_default!(QuerySoftwareCrcCommand);
 impl_message_ops!(QuerySoftwareCrcCommand);
 impl_aux_ops!(QuerySoftwareCrcCommand);

--- a/src/query_software_crc/reply.rs
+++ b/src/query_software_crc/reply.rs
@@ -2,9 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, impl_omnibus_nop_reply,
-    len::QUERY_SOFTWARE_CRC_REPLY, seven_bit_u16, u16_seven_bit, AuxCommand, AuxCommandOps,
-    MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, impl_omnibus_nop_reply, len::QUERY_SOFTWARE_CRC_REPLY,
+    seven_bit_u16, u16_seven_bit, AuxCommand, AuxCommandOps, MessageOps, MessageType,
 };
 
 pub mod index {
@@ -47,7 +46,7 @@ pub mod index {
 /// assert_eq!(exp_crc, crc);
 /// ```
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QuerySoftwareCrcReply {
     buf: [u8; QUERY_SOFTWARE_CRC_REPLY],
 }
@@ -76,7 +75,6 @@ impl QuerySoftwareCrcReply {
     }
 }
 
-impl_default!(QuerySoftwareCrcReply);
 impl_message_ops!(QuerySoftwareCrcReply);
 impl_omnibus_nop_reply!(QuerySoftwareCrcReply);
 impl_aux_ops!(QuerySoftwareCrcReply);

--- a/src/query_value_table/command.rs
+++ b/src/query_value_table/command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
+    impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
     len::QUERY_VALUE_TABLE_COMMAND, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
 };
 
@@ -17,7 +17,8 @@ use crate::{
 /// |:------|:----:|:----:|:----:|:-------:|:------:|:------:|:------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3       | 4      | 5      | 6      | 7    | 8   |
 /// | Value | 0x02 | 0x09 | 0x7n | 0x06    | nn     | nn     | nn     | 0x03 | zz  |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryValueTableCommand {
     buf: [u8; QUERY_VALUE_TABLE_COMMAND],
 }
@@ -37,7 +38,6 @@ impl QueryValueTableCommand {
     }
 }
 
-impl_default!(QueryValueTableCommand);
 impl_message_ops!(QueryValueTableCommand);
 impl_omnibus_extended_command!(QueryValueTableCommand);
 impl_extended_ops!(QueryValueTableCommand);

--- a/src/query_value_table/reply.rs
+++ b/src/query_value_table/reply.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Represents a denomination in non-extended mode.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BaseDenomination {
     /// Note value index reported starting with '1' and ending with '7'.
     note_index: usize,

--- a/src/query_variant_id/command.rs
+++ b/src/query_variant_id/command.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::QUERY_VARIANT_ID_COMMAND, AuxCommand,
-    AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::QUERY_VARIANT_ID_COMMAND, AuxCommand, AuxCommandOps,
+    MessageOps, MessageType,
 };
 
 /// Query Variant ID Number - Command (Subtype 0x0F)
@@ -21,7 +21,7 @@ use crate::{
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x0F    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryVariantIdCommand {
     buf: [u8; QUERY_VARIANT_ID_COMMAND],
 }
@@ -40,7 +40,6 @@ impl QueryVariantIdCommand {
     }
 }
 
-impl_default!(QueryVariantIdCommand);
 impl_message_ops!(QueryVariantIdCommand);
 impl_aux_ops!(QueryVariantIdCommand);
 

--- a/src/query_variant_id/reply.rs
+++ b/src/query_variant_id/reply.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::QUERY_VARIANT_ID_REPLY,
-    MessageOps, MessageType, PartVersion, ProjectNumber, VariantPartNumber,
+    impl_message_ops, impl_omnibus_nop_reply, len::QUERY_VARIANT_ID_REPLY, MessageOps, MessageType,
+    PartVersion, ProjectNumber, VariantPartNumber,
 };
 
 pub mod index {
@@ -28,7 +28,7 @@ pub mod index {
 ///
 /// See [ProjectNumber](crate::ProjectNumber) for formatting details.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryVariantIdReply {
     buf: [u8; QUERY_VARIANT_ID_REPLY],
 }
@@ -66,7 +66,6 @@ impl QueryVariantIdReply {
     }
 }
 
-impl_default!(QueryVariantIdReply);
 impl_message_ops!(QueryVariantIdReply);
 impl_omnibus_nop_reply!(QueryVariantIdReply);
 

--- a/src/query_variant_name/command.rs
+++ b/src/query_variant_name/command.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, impl_omnibus_command_ops,
-    len::QUERY_VARIANT_NAME_COMMAND, AuxCommand, AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, impl_omnibus_command_ops, len::QUERY_VARIANT_NAME_COMMAND,
+    AuxCommand, AuxCommandOps, MessageOps, MessageType,
 };
 
 /// Query Variant Name - Command (Subtype 0x08)
@@ -18,6 +18,8 @@ use crate::{
 /// |:------|:----:|:----:|:----:|:------:|:------:|:-------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x08    | 0x03 | zz  |
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryVariantNameCommand {
     buf: [u8; QUERY_VARIANT_NAME_COMMAND],
 }
@@ -37,7 +39,6 @@ impl QueryVariantNameCommand {
     }
 }
 
-impl_default!(QueryVariantNameCommand);
 impl_message_ops!(QueryVariantNameCommand);
 impl_omnibus_command_ops!(QueryVariantNameCommand);
 impl_aux_ops!(QueryVariantNameCommand);

--- a/src/query_variant_part_number/command.rs
+++ b/src/query_variant_part_number/command.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::QUERY_VARIANT_PART_NUMBER_COMMAND,
-    AuxCommand, AuxCommandOps, MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::QUERY_VARIANT_PART_NUMBER_COMMAND, AuxCommand,
+    AuxCommandOps, MessageOps, MessageType,
 };
 
 /// Query Variant Part Number - Command (Subtype 0x09)
@@ -14,7 +14,7 @@ use crate::{
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x00   | 0x00   | 0x09    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryVariantPartNumberCommand {
     buf: [u8; QUERY_VARIANT_PART_NUMBER_COMMAND],
 }
@@ -33,7 +33,6 @@ impl QueryVariantPartNumberCommand {
     }
 }
 
-impl_default!(QueryVariantPartNumberCommand);
 impl_message_ops!(QueryVariantPartNumberCommand);
 impl_aux_ops!(QueryVariantPartNumberCommand);
 

--- a/src/query_variant_part_number/reply.rs
+++ b/src/query_variant_part_number/reply.rs
@@ -2,8 +2,8 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_message_ops, impl_omnibus_nop_reply, len::QUERY_VARIANT_PART_NUMBER_REPLY,
-    MessageOps, MessageType, PartVersion, ProjectNumber, VariantPartNumber,
+    impl_message_ops, impl_omnibus_nop_reply, len::QUERY_VARIANT_PART_NUMBER_REPLY, MessageOps,
+    MessageType, PartVersion, ProjectNumber, VariantPartNumber,
 };
 
 pub mod index {
@@ -33,7 +33,7 @@ pub mod index {
 ///
 /// See [ProjectNumber](crate::ProjectNumber) for formatting details.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct QueryVariantPartNumberReply {
     buf: [u8; QUERY_VARIANT_PART_NUMBER_REPLY],
 }
@@ -71,7 +71,6 @@ impl QueryVariantPartNumberReply {
     }
 }
 
-impl_default!(QueryVariantPartNumberReply);
 impl_message_ops!(QueryVariantPartNumberReply);
 impl_omnibus_nop_reply!(QueryVariantPartNumberReply);
 

--- a/src/set_escrow_timeout/command.rs
+++ b/src/set_escrow_timeout/command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
+    impl_extended_ops, impl_message_ops, impl_omnibus_extended_command,
     len::SET_ESCROW_TIMEOUT_COMMAND, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
 };
 
@@ -25,6 +25,8 @@ const TIMEOUT_MASK: u8 = 0x7f;
 /// |:------|:----:|:----:|:----:|:-------:|:------:|:------:|:------:|:-----:|:-------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3       | 4      | 5      | 6      | 7     | 8       | 9    | 10  |
 /// | Value | 0x02 | 0x0B | 0x7n | 0x04    | nn     | nn     | nn     | nn    | nn      | 0x03 | zz  |
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct SetEscrowTimeoutCommand {
     buf: [u8; SET_ESCROW_TIMEOUT_COMMAND],
 }
@@ -72,7 +74,6 @@ impl SetEscrowTimeoutCommand {
     }
 }
 
-impl_default!(SetEscrowTimeoutCommand);
 impl_message_ops!(SetEscrowTimeoutCommand);
 impl_extended_ops!(SetEscrowTimeoutCommand);
 impl_omnibus_extended_command!(SetEscrowTimeoutCommand);

--- a/src/set_escrow_timeout/reply.rs
+++ b/src/set_escrow_timeout/reply.rs
@@ -2,7 +2,7 @@ use crate::std;
 use std::fmt;
 
 use crate::{
-    impl_default, impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
+    impl_extended_ops, impl_message_ops, impl_omnibus_extended_reply,
     len::SET_ESCROW_TIMEOUT_REPLY, ExtendedCommand, ExtendedCommandOps, MessageOps, MessageType,
     OmnibusReplyOps,
 };
@@ -22,7 +22,8 @@ use crate::{
 /// |:------|:----:|:----:|:----:|:-------:|:------:|:------:|:------:|:------:|:------:|:------:|:----:|:---:|
 /// | Byte  | 0    | 1    | 2    | 3       | 4      | 5      | 6      | 7      | 8      | 9      | 10   | 11  |
 /// | Value | 0x02 | 0x0C | 0X7n | 0x04    | nn     | nn     | nn     | nn     | nn     | nn     | 0x03 | zz  |
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct SetEscrowTimeoutReply {
     buf: [u8; SET_ESCROW_TIMEOUT_REPLY],
 }
@@ -42,7 +43,6 @@ impl SetEscrowTimeoutReply {
     }
 }
 
-impl_default!(SetEscrowTimeoutReply);
 impl_message_ops!(SetEscrowTimeoutReply);
 impl_extended_ops!(SetEscrowTimeoutReply);
 impl_omnibus_extended_reply!(SetEscrowTimeoutReply);

--- a/src/soft_reset.rs
+++ b/src/soft_reset.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_aux_ops, impl_default, impl_message_ops, len::SOFT_RESET, AuxCommand, AuxCommandOps,
-    MessageOps, MessageType,
+    impl_aux_ops, impl_message_ops, len::SOFT_RESET, AuxCommand, AuxCommandOps, MessageOps,
+    MessageType,
 };
 
 pub mod index {
@@ -23,7 +23,7 @@ pub mod index {
 /// | Byte  | 0    | 1    | 2    | 3      | 4      | 5       | 6    | 7   |
 /// | Value | 0x02 | 0x08 | 0x6n | 0x7F   | 0x7F   | 0x7F    | 0x03 | zz  |
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct SoftReset {
     buf: [u8; SOFT_RESET],
 }
@@ -48,7 +48,6 @@ impl SoftReset {
     }
 }
 
-impl_default!(SoftReset);
 impl_message_ops!(SoftReset);
 impl_aux_ops!(SoftReset);
 

--- a/src/status/document_status.rs
+++ b/src/status/document_status.rs
@@ -1,13 +1,13 @@
 use crate::std::fmt;
 
 use crate::{
-    banknote::{BanknoteOrientation, NoteTableItem},
+    banknote::{Banknote, BanknoteOrientation, NoteTableItem},
     denomination::StandardDenomination,
 };
 
 /// An accepted [NoteTableItem].
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct AcceptedNoteTableItem {
     note_table_item: NoteTableItem,
     banknote_orientation: BanknoteOrientation,
@@ -25,10 +25,10 @@ impl AcceptedNoteTableItem {
         }
     }
 
-    /// Creates a default [AcceptedNoteTableItem].
-    pub const fn default() -> Self {
+    /// Creates a new null [AcceptedNoteTableItem].
+    pub const fn null() -> Self {
         Self {
-            note_table_item: NoteTableItem::default(),
+            note_table_item: NoteTableItem::new(0, Banknote::null()),
             banknote_orientation: BanknoteOrientation::default(),
         }
     }
@@ -68,7 +68,7 @@ impl fmt::Display for AcceptedNoteTableItem {
 
 /// Values that represent document events.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum DocumentEvent {
     DispensedEvent = 0,
     EscrowedEvent = 1,
@@ -78,12 +78,13 @@ pub enum DocumentEvent {
     StackedEvent = 5,
     MissingNoteReportReadyEvent = 6,
     EscrowSessionSummaryReportReadyEvent = 7,
+    #[default]
     NoneEvent = 8,
 }
 
 impl DocumentEvent {
     /// Creates a default [DocumentEvent].
-    pub const fn default() -> Self {
+    pub const fn new() -> Self {
         Self::NoneEvent
     }
 }
@@ -120,8 +121,9 @@ impl fmt::Display for DocumentEvent {
 
 /// Values that represent document routing directions.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum DocumentRouting {
+    #[default]
     NoRoute = 0,
     EscrowToRecycler = 1,
     RecyclerToCashbox = 2,
@@ -134,7 +136,7 @@ pub enum DocumentRouting {
 
 impl DocumentRouting {
     /// Creates a default [DocumentRouting].
-    pub const fn default() -> Self {
+    pub const fn new() -> Self {
         Self::NoRoute
     }
 }
@@ -168,7 +170,7 @@ impl fmt::Display for DocumentRouting {
 
 /// A document status.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct DocumentStatus {
     /// The [DocumentEvent].
     document_event: DocumentEvent,
@@ -206,16 +208,6 @@ impl DocumentStatus {
             document_routing,
             accepted_note_table_item,
             standard_denomination,
-        }
-    }
-
-    /// Creates a default [DocumentStatus].
-    pub const fn default() -> Self {
-        Self {
-            document_event: DocumentEvent::default(),
-            document_routing: DocumentRouting::default(),
-            accepted_note_table_item: AcceptedNoteTableItem::default(),
-            standard_denomination: StandardDenomination::none(),
         }
     }
 


### PR DESCRIPTION
Adds common derive traits to command and reply types that were missing
them. Results in better ergonomics for crate users.

Removes implementing the `Default` trait using `impl_default` where possible, and substitutes `const fn default` impls with the `Default` trait. This allows containing types to also implement `Default` with the derive macro.

Bumps the minor version to account for subtle changes to the API. Most notably using the `Default` trait in place of the `const fn default` implementations. Previous callers that are in a `const` context will be broken by the new API.