### PR TITLE
fixup: variant reply API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebds"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "Messages and related types for implementing the EBDS serial communication protocol"

--- a/src/variant/reply.rs
+++ b/src/variant/reply.rs
@@ -2,8 +2,8 @@ use crate::{
     index, inner_enum, len, std::fmt, AdvancedBookmarkModeReply, AuxCommand, Banknote,
     BaudRateChangeReply, ClearAuditDataRequestAck, ClearAuditDataRequestResults, Control,
     DocumentStatus, Error, ExtendedCommand, ExtendedNoteInhibitsReplyAlt, ExtendedNoteReply,
-    FlashDownloadReply7bit, FlashDownloadReply8bit, MessageOps, MessageType, NoteRetrievedEvent,
-    NoteRetrievedReply, OmnibusReply, OmnibusReplyOps, QueryApplicationIdReply,
+    FlashDownloadReply, FlashDownloadReply7bit, FlashDownloadReply8bit, MessageOps, MessageType,
+    NoteRetrievedEvent, NoteRetrievedReply, OmnibusReply, OmnibusReplyOps, QueryApplicationIdReply,
     QueryApplicationPartNumberReply, QueryBootPartNumberReply, QueryDeviceCapabilitiesReply,
     QuerySoftwareCrcReply, QueryValueTableReply, QueryVariantIdReply, QueryVariantNameReply,
     QueryVariantPartNumberReply, Result, SetEscrowTimeoutReply, StartDownloadReply,
@@ -201,6 +201,52 @@ impl ReplyVariant {
             Self::QueryVariantIdReply(msg) => msg.into(),
             _ => OmnibusReply::new(),
         }
+    }
+
+    /// Gets whether [ReplyVariant] contains a `FlashDownloadReply` message.
+    pub fn is_flash_download_reply(&self) -> bool {
+        self.is_flash_download_reply7bit() || self.is_flash_download_reply8bit()
+    }
+
+    /// Gets a reference to the [ReplyVariant] as a [FlashDownloadReply] trait object.
+    pub fn as_flash_download_reply(&self) -> Result<&dyn FlashDownloadReply> {
+        match self {
+            Self::FlashDownloadReply7bit(msg) => Ok(msg),
+            Self::FlashDownloadReply8bit(msg) => Ok(msg),
+            _ => Err(Error::failure(format!(
+                "invalid reply variant, expected FlashDownloadReply, have: {self}"
+            ))),
+        }
+    }
+
+    /// Convenience alias for [is_flash_download_reply8bit()](Self::is_flash_download_reply8bit).
+    pub fn is_flash_download_reply_7bit(&self) -> bool {
+        self.is_flash_download_reply7bit()
+    }
+
+    /// Convenience alias for [as_flash_download_reply7bit()](Self::as_flash_download_reply7bit).
+    pub fn as_flash_download_reply_7bit(&self) -> Result<&FlashDownloadReply7bit> {
+        self.as_flash_download_reply7bit()
+    }
+
+    /// Convenience alias for [into_flash_download_reply7bit()](Self::into_flash_download_reply7bit).
+    pub fn into_flash_download_reply_7bit(self) -> Result<FlashDownloadReply7bit> {
+        self.into_flash_download_reply7bit()
+    }
+
+    /// Convenience alias for [is_flash_download_reply8bit()](Self::is_flash_download_reply8bit).
+    pub fn is_flash_download_reply_8bit(&self) -> bool {
+        self.is_flash_download_reply8bit()
+    }
+
+    /// Convenience alias for [as_flash_download_reply8bit()](Self::as_flash_download_reply8bit).
+    pub fn as_flash_download_reply_8bit(&self) -> Result<&FlashDownloadReply8bit> {
+        self.as_flash_download_reply8bit()
+    }
+
+    /// Convenience alias for [into_flash_download_reply8bit()](Self::into_flash_download_reply8bit).
+    pub fn into_flash_download_reply_8bit(self) -> Result<FlashDownloadReply8bit> {
+        self.into_flash_download_reply8bit()
     }
 
     /// Converts a [ReplyVariant] into a [Banknote].


### PR DESCRIPTION
Adds convenience alias functions for `FlashDownloadReply` deconstruction
functions that do not exaclty map to the old API. For example, the snake
case conversion from `paste` converts `Reply7bit` to `reply7bit` instead
of `reply_7bit`.

Adds deconstruction methods to get a reference to `ReplyVariant` as a
`FlashDownloadReply` trait object.

Bumps the release version to include fixups for the `ReplyVariant` API.