### PR TITLE
variant: fix formatting for error message

### DIFF
--- a/src/variant/reply.rs
+++ b/src/variant/reply.rs
@@ -284,9 +284,9 @@ impl ReplyVariant {
         let exp_msg_type = MessageType::AuxCommand;
 
         if msg_type != exp_msg_type {
-            return Err(Error::failure(
+            return Err(Error::failure(format!(
                 "invalid message type: {msg_type}, expected: {exp_msg_type}",
-            ));
+            )));
         }
 
         match command {


### PR DESCRIPTION
Fixes the format string for an error message to use the `format!` macro.

Previously, the message was a static string.