### PR TITLE
version: bump to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ebds"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "Messages and related types for implementing the EBDS serial communication protocol"
 keywords = ["no-std", "serial", "ebds", "bill-acceptor", "bill-validator"]
 categories = ["no-std"]
-repository = "https://github.com/ebds-rs/ebds"
+repository = "https://github.com/decapod-atm/ebds"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
Bumps the patch release version.

Includes:

- minor fix for error string
- lint fixes